### PR TITLE
Get ready for refreshing just with access tokens

### DIFF
--- a/cloud_info_provider/auth_refreshers/__init__.py
+++ b/cloud_info_provider/auth_refreshers/__init__.py
@@ -20,3 +20,11 @@ class BaseRefresher(object):
     @staticmethod
     def populate_parser(parser):
         """Populate the argparser 'parser' with the needed options."""
+
+
+class OidcBaseRefresher(BaseRefresher):
+    def _update_provider(self, provider, token):
+        # this requires some inner knowledge on the oidc auth of OpenStack
+        # and won't work for others, but I'm not sure if we can make
+        # this generic
+        provider.opts.os_access_token = token

--- a/cloud_info_provider/auth_refreshers/access_token.py
+++ b/cloud_info_provider/auth_refreshers/access_token.py
@@ -1,5 +1,4 @@
-import requests
-from cloud_info_provider import auth_refreshers, exceptions
+from cloud_info_provider import auth_refreshers
 
 
 class AccessTokenRefresh(auth_refreshers.OidcBaseRefresher):

--- a/cloud_info_provider/auth_refreshers/access_token.py
+++ b/cloud_info_provider/auth_refreshers/access_token.py
@@ -3,8 +3,8 @@ from cloud_info_provider import auth_refreshers, exceptions
 
 
 class AccessTokenRefresh(auth_refreshers.OidcBaseRefresher):
-    """Just uses the access token available at the auth configuration
-    """
+    """Just uses the access token available at the auth configuration"""
+
     def _update_provider(self, provider, token):
         # this requires some inner knowledge on the oidc auth of OpenStack
         # and won't work for others, but I'm not sure if we can make

--- a/cloud_info_provider/auth_refreshers/access_token.py
+++ b/cloud_info_provider/auth_refreshers/access_token.py
@@ -3,12 +3,5 @@ from cloud_info_provider import auth_refreshers
 
 class AccessTokenRefresh(auth_refreshers.OidcBaseRefresher):
     """Just uses the access token available at the auth configuration"""
-
-    def _update_provider(self, provider, token):
-        # this requires some inner knowledge on the oidc auth of OpenStack
-        # and won't work for others, but I'm not sure if we can make
-        # this generic
-        provider.opts.os_access_token = token
-
     def refresh(self, provider, access_token=None, **kwargs):
         self._update_provider(provider, access_token)

--- a/cloud_info_provider/auth_refreshers/access_token.py
+++ b/cloud_info_provider/auth_refreshers/access_token.py
@@ -3,5 +3,6 @@ from cloud_info_provider import auth_refreshers
 
 class AccessTokenRefresh(auth_refreshers.OidcBaseRefresher):
     """Just uses the access token available at the auth configuration"""
+
     def refresh(self, provider, access_token=None, **kwargs):
         self._update_provider(provider, access_token)

--- a/cloud_info_provider/auth_refreshers/access_token.py
+++ b/cloud_info_provider/auth_refreshers/access_token.py
@@ -1,0 +1,15 @@
+import requests
+from cloud_info_provider import auth_refreshers, exceptions
+
+
+class AccessTokenRefresh(auth_refreshers.OidcBaseRefresher):
+    """Just uses the access token available at the auth configuration
+    """
+    def _update_provider(self, provider, token):
+        # this requires some inner knowledge on the oidc auth of OpenStack
+        # and won't work for others, but I'm not sure if we can make
+        # this generic
+        provider.opts.os_access_token = token
+
+    def refresh(self, provider, access_token=None, **kwargs):
+        self._update_provider(provider, access_token)

--- a/cloud_info_provider/auth_refreshers/access_token.py
+++ b/cloud_info_provider/auth_refreshers/access_token.py
@@ -1,7 +1,7 @@
 from cloud_info_provider import auth_refreshers
 
 
-class AccessTokenRefresh(auth_refreshers.OidcBaseRefresher):
+class AccessToken(auth_refreshers.OidcBaseRefresher):
     """Just uses the access token available at the auth configuration"""
 
     def refresh(self, provider, access_token=None, **kwargs):

--- a/cloud_info_provider/auth_refreshers/oidc_refresh.py
+++ b/cloud_info_provider/auth_refreshers/oidc_refresh.py
@@ -2,7 +2,7 @@ import requests
 from cloud_info_provider import auth_refreshers, exceptions
 
 
-class OidcRefreshToken(auth_refreshers.BaseRefresher):
+class OidcRefreshToken(auth_refreshers.OidcBaseRefresher):
     """Refreshes OAuth 2.0 access tokens using refresh_token grant.
 
     OAuth2.0 token endpoint and credentials are specified in the options to
@@ -36,12 +36,6 @@ class OidcRefreshToken(auth_refreshers.BaseRefresher):
             return r.json()["access_token"]
         except (ValueError, KeyError, requests.exceptions.RequestException) as e:
             raise exceptions.RefresherException("Unable to get token %s" % e)
-
-    def _update_provider(self, provider, token):
-        # this requires some inner knowledge on the oidc auth of OpenStack
-        # and won't work for others, but I'm not sure if we can make
-        # this generic
-        provider.opts.os_access_token = token
 
     def refresh(self, provider, **kwargs):
         token = self._refresh_token(

--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -21,10 +21,10 @@ from six.moves.urllib.parse import urljoin, urlparse
 def _rescope(f):
     @functools.wraps(f)
     def inner(self, **kwargs):
-        auth = kwargs.get("auth")
-        vo = kwargs.get("vo")
-        region_name = auth.get("region_name", self.os_region)
-        self._rescope_project(auth["project_id"], vo, region_name)
+        auth = {"region_name": self.os_region}
+        auth.update(kwargs.get("auth"))
+        auth.update({"vo": kwargs.get("vo")})
+        self._rescope_project(auth)
         return f(self, **kwargs)
 
     return inner
@@ -104,18 +104,17 @@ class OpenStackProvider(base.BaseProvider):
             share["project"] = share.get("auth", {}).get("project_id")
         return shares
 
-    def _rescope_project(self, project_id, vo, region_name=None):
+    def _rescope_project(self, auth):
         """Switch to new OS project whenever there is a change.
 
         It updates every OpenStack client used in case of new project.
         """
+        project_id = auth["project_id"]
         if self.project_id == project_id:
             return
         self.opts.os_project_id = project_id
-        # make sure that it also works for v2voms
-        self.opts.os_tenant_id = project_id
         if self.auth_refresher:
-            self.auth_refresher.refresh(self, project_id=project_id, vo=vo)
+            self.auth_refresher.refresh(self, **auth)
         self.auth_plugin = loading.load_auth_from_argparse_arguments(self.opts)
         self.session = loading.load_session_from_argparse_arguments(
             self.opts, auth=self.auth_plugin

--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -110,6 +110,7 @@ class OpenStackProvider(base.BaseProvider):
         It updates every OpenStack client used in case of new project.
         """
         project_id = auth["project_id"]
+        region_name = auth.get("region_name", None)
         if self.project_id == project_id:
             return
         self.opts.os_project_id = project_id

--- a/cloud_info_provider/tests/test_auth_refreshers.py
+++ b/cloud_info_provider/tests/test_auth_refreshers.py
@@ -6,9 +6,23 @@ import argparse
 
 import mock
 import requests
-from cloud_info_provider.auth_refreshers import oidc_refresh, oidc_vo_refresh
+from cloud_info_provider.auth_refreshers import access_token, oidc_refresh, oidc_vo_refresh
 from cloud_info_provider.exceptions import RefresherException
 from cloud_info_provider.tests import base
+
+
+class AccessTokenRefreshTest(base.TestCase):
+    def test_refresh(self):
+        class FakeProvider(object):
+            def __init__(self):
+                self.opts = mock.Mock()
+
+        provider = FakeProvider()
+        refresher = access_token.AccessTokenRefresh(None)
+        token = "this token"
+        refresher.refresh(provider, access_token=token, ignore=True)
+        self.assertEqual("this token", provider.opts.os_access_token)
+
 
 
 class OidcRefreshOptionsTest(base.TestCase):

--- a/cloud_info_provider/tests/test_auth_refreshers.py
+++ b/cloud_info_provider/tests/test_auth_refreshers.py
@@ -6,7 +6,11 @@ import argparse
 
 import mock
 import requests
-from cloud_info_provider.auth_refreshers import access_token, oidc_refresh, oidc_vo_refresh
+from cloud_info_provider.auth_refreshers import (
+    access_token,
+    oidc_refresh,
+    oidc_vo_refresh,
+)
 from cloud_info_provider.exceptions import RefresherException
 from cloud_info_provider.tests import base
 
@@ -22,7 +26,6 @@ class AccessTokenRefreshTest(base.TestCase):
         token = "this token"
         refresher.refresh(provider, access_token=token, ignore=True)
         self.assertEqual("this token", provider.opts.os_access_token)
-
 
 
 class OidcRefreshOptionsTest(base.TestCase):

--- a/cloud_info_provider/tests/test_auth_refreshers.py
+++ b/cloud_info_provider/tests/test_auth_refreshers.py
@@ -15,14 +15,14 @@ from cloud_info_provider.exceptions import RefresherException
 from cloud_info_provider.tests import base
 
 
-class AccessTokenRefreshTest(base.TestCase):
+class AccessTokenTest(base.TestCase):
     def test_refresh(self):
         class FakeProvider(object):
             def __init__(self):
                 self.opts = mock.Mock()
 
         provider = FakeProvider()
-        refresher = access_token.AccessTokenRefresh(None)
+        refresher = access_token.AccessToken(None)
         token = "this token"
         refresher.refresh(provider, access_token=token, ignore=True)
         self.assertEqual("this token", provider.opts.os_access_token)

--- a/cloud_info_provider/tests/test_openstack.py
+++ b/cloud_info_provider/tests/test_openstack.py
@@ -82,9 +82,10 @@ class OpenStackProviderAuthTest(base.TestCase):
             session = mock.Mock()
             session.get_project_id.return_value = "foo"
             m_load_session.return_value = session
-            self.provider._rescope_project("foo", "bar")
+            auth = {"project_id": "foo", "vo": "bar"}
+            self.provider._rescope_project(auth)
             self.assertEqual("foo", self.provider.project_id)
-            m_refresh.assert_called_with(self.provider, project_id="foo", vo="bar")
+            m_refresh.assert_called_with(self.provider, **auth)
 
 
 class OpenStackProviderTest(base.TestCase):

--- a/cloud_info_provider/tests/test_openstack.py
+++ b/cloud_info_provider/tests/test_openstack.py
@@ -67,7 +67,8 @@ class OpenStackProviderAuthTest(base.TestCase):
             session = mock.Mock()
             session.get_project_id.return_value = "foo"
             m_load_session.return_value = session
-            self.provider._rescope_project("foo", "bar")
+            auth = {"project_id": "foo", "vo": "bar"}
+            self.provider._rescope_project(auth)
             self.assertEqual("foo", self.provider.project_id)
 
     def test_rescope_refresh(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ cip.collectors =
 cip.auth_refreshers =
     oidcrefresh = cloud_info_provider.auth_refreshers.oidc_refresh:OidcRefreshToken
     oidcvorefresh = cloud_info_provider.auth_refreshers.oidc_vo_refresh:OidcVORefreshToken
+    accesstoken = cloud_info_provider.auth_refreshers.access_token:AccessToken
 cip.publishers =
     stdout = cloud_info_provider.publishers.stdout:StdOutPublisher
     ams = cloud_info_provider.publishers.ams:AMSPublisher


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.
If you consider this a substantial pull request, which according to the
contributing guidelines should give you the right to be added to the list
of contributors or authors, please mark the PR as
"consider author for inclusion in Contributors" or
"consider author for inclusion in Authors" for the maintainers.
-->

# Summary

<!-- Describe in plain English what this PR does -->
This change brings support to use access tokens directly for authentication to the OpenStack projects. For every share, the `accesstoken` refresher will take the information available in the `auth` config of the share and just pass it to the OpenStack provider so it can be further used. It does not try to refresh or any other kind of magic, the token is assumed to be valid for the project.

Sample configuration:
```
compute:
  shares:
    vo-name:
      auth:
        project_id: "the project id"
        access_token: "<the access token>"
```

Using it from command line:
```
$ cloud-info-provider-service \
        --yaml-file openstack.yaml \
        --middleware openstack \
        --auth-refresher accesstoken \
        --os-auth-type v3oidcaccesstoken \
        --os-identitiy-provider egi.eu \
        --os-protocol openid \
        --format glue21
```
---

<!-- Add the related issue here, e.g. #6 -->

**Related issue :**


