### PR TITLE
Potential fix for code scanning alert no. 2: Use of insecure SSL/TLS version

### DIFF
--- a/cloud_info_provider/providers/utils.py
+++ b/cloud_info_provider/providers/utils.py
@@ -108,7 +108,7 @@ def get_endpoint_ca_information(endpoint_url, insecure=False):
         port = 443
 
     try:
-        ctx = SSL.Context(SSL.SSLv23_METHOD)
+        ctx = SSL.Context(SSL.TLSv1_2_METHOD)
         ctx.set_options(SSL.OP_NO_SSLv2)
         ctx.set_options(SSL.OP_NO_SSLv3)
         ctx.set_verify(verify, lambda conn, cert, errno, depth, ok: ok)


### PR DESCRIPTION
Potential fix for [https://github.com/EGI-Federation/cloud-info-provider/security/code-scanning/2](https://github.com/EGI-Federation/cloud-info-provider/security/code-scanning/2)

To fix the issue, we will replace the use of `SSL.SSLv23_METHOD` with `SSL.TLSv1_2_METHOD`. This explicitly enforces the use of TLSv1.2, a secure and modern protocol. Additionally, we will retain the existing options (`SSL.OP_NO_SSLv2` and `SSL.OP_NO_SSLv3`) for completeness, although they are redundant when using `TLSv1_2_METHOD`.

The changes will be made in the `get_endpoint_ca_information` function in the file `cloud_info_provider/providers/utils.py`. Specifically, we will update the line where the SSL context is created.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
